### PR TITLE
Use opentofu 1.6.0 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # ansible-collection-terraform
 
 Ansible collection that enables the provisioning of infrastructure and population of the
-in-memory inventory using Terraform.
+in-memory inventory using [OpenTofu](https://github.com/opentofu/opentofu).
+
+For backward-compatibilty all role variables etc. refer to `terraform`.

--- a/roles/install/defaults/main.yml
+++ b/roles/install/defaults/main.yml
@@ -1,7 +1,7 @@
 # Acceptable OpenTofu versions. If a binary fulfilling these criteria is not found,
 # terraform_version_max will be downloaded.
-terraform_version_min: 1.6.0-alpha5
-terraform_version_max: 1.6.0-alpha5
+terraform_version_min: 1.6.0
+terraform_version_max: 1.6.0
 
 # The OS variant and architecture to use
 terraform_os: "{{ ansible_system | lower }}"

--- a/roles/install/defaults/main.yml
+++ b/roles/install/defaults/main.yml
@@ -1,18 +1,15 @@
-# Acceptable Terraform versions. If a binary fulfilling these criteria is not found,
+# Acceptable OpenTofu versions. If a binary fulfilling these criteria is not found,
 # terraform_version_max will be downloaded.
-# v1.5.5 is the latest version available under the MPL license:
-# https://www.hashicorp.com/license-faq#products-covered-by-bsl
-terraform_version_min: 1.5.5
-terraform_version_max: 1.5.5
+terraform_version_min: 1.6.0-alpha5
+terraform_version_max: 1.6.0-alpha5
 
 # The OS variant and architecture to use
 terraform_os: "{{ ansible_system | lower }}"
 terraform_architecture: "{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
 # The name of the Terraform zip
-terraform_zip_name: terraform_{{ terraform_version_max }}_{{ terraform_os }}_{{ terraform_architecture }}.zip
+terraform_zip_name: tofu_{{ terraform_version_max }}_{{ terraform_os }}_{{ terraform_architecture }}.zip
 # The URL of the Terraform binary
-terraform_binary_url: https://releases.hashicorp.com/terraform/{{ terraform_version_max }}/{{ terraform_zip_name }}
-
+terraform_binary_url: https://github.com/opentofu/opentofu/releases/download/v{{ terraform_version_max }}/{{ terraform_zip_name }}
 # The directory to put the Terraform binary in if we download it
 terraform_binary_directory: /usr/local/bin
 

--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Check if Terraform binary exists in search directories
   stat:
-    path: "{{ item }}/terraform"
+    path: "{{ item }}/tofu"
   register: terraform_binary_paths
   loop: "{{ terraform_search_directories }}"
 
@@ -39,6 +39,10 @@
     terraform_detected_version: "{{ terraform_acceptable_versions.0.1 }}"
   when: "terraform_acceptable_versions | length > 0"
 
+- name: show terraform_binary_path
+  debug:
+    var: terraform_binary_path
+
 - name: Download Terraform binary if an acceptable version is not available
   block:
     - name: Ensure Terraform bin directory exists
@@ -54,7 +58,7 @@
 
     - name: Set current Terraform path fact
       set_fact:
-        terraform_binary_path: "{{ terraform_binary_directory }}/terraform"
+        terraform_binary_path: "{{ terraform_binary_directory }}/tofu"
   when: terraform_binary_path is not defined
   become: "{{ terraform_download_binary_become }}"
 


### PR DESCRIPTION
NB: Currently no changes have been made to repo or variable names.