### PR TITLE
Testing unlocking terraform state at EBI

### DIFF
--- a/roles/infra/tasks/main.yml
+++ b/roles/infra/tasks/main.yml
@@ -66,6 +66,8 @@
     variables: "{{ terraform_variables }}"
   register: terraform_provision_state
   when: not terraform_readonly
+  environment:
+    TF_HTTP_UNLOCK_METHOD: DELETE
 
 - name: Get outputs from Terraform state
   when: terraform_readonly


### PR DESCRIPTION
EBI GitLab is facing issues on releasing terraform state lock, hence adding new method to test.